### PR TITLE
Update ExportGrailsPlugin.groovy

### DIFF
--- a/ExportGrailsPlugin.groovy
+++ b/ExportGrailsPlugin.groovy
@@ -41,7 +41,7 @@ and can be extended to add additional formats.
 		  		try {
 		  			//Override default renderer configuration
 					if(application.config?.export."${key}"){
-						value = grailsApplication.config.export."${key}"
+						value = application.config.export."${key}"
 					}
 		  			
 		      		Class clazz = Class.forName(value, true, new GroovyClassLoader())


### PR DESCRIPTION
I need to implement a specific my Excel exporter. I found in the file ExportGrailsPlugin.grovvy, an undocumented possibility of setting up your own Excel exporter. Unfortunately there is a bug that sends the application to crash if I set in config.groovy the custome exporter. The fix is ​​very simple and consists in modifying the grailsApplication attribute to application in line 44. The problem is that i'm using grails 1.3.7 and i can upgrade to version 1.1 at the maximum.
