### PR TITLE
Support title cell formatting in Excel exports

### DIFF
--- a/src/groovy/de/andreasschmitt/export/builder/ExcelBuilder.groovy
+++ b/src/groovy/de/andreasschmitt/export/builder/ExcelBuilder.groovy
@@ -234,6 +234,7 @@ class ExcelBuilder extends BuilderSupport {
 
                     if (attributes.useBorder) cellFormat.setBorder(Border.ALL, BorderLineStyle.THIN)
                     if (attributes.backColor) cellFormat.setBackground(attributes.backColor)
+                    if (attributes.alignment) cellFormat.setAlignment(attributes.alignment)
 
                     formats.put(format, cellFormat)
     			}
@@ -242,6 +243,14 @@ class ExcelBuilder extends BuilderSupport {
                     e.printStackTrace();
     			}
     			break
+            case "mergeCells":
+                log.debug("attributes: ${attributes}")
+                try {
+                    sheet.mergeCells(attributes?.startColumn, attributes?.startRow, attributes?.endColumn, attributes?.endRow)
+                } catch (Exception ex) {
+                    log.error("Could not merge cells.  Ensure startColumn, startRow, endColumn, endRow attributes are set.  Attributes: ${attributes}")
+                }
+                break
     	}
     	
         return null


### PR DESCRIPTION
Adding support for merging and aligning title cells in Excel exports.  Example:

``` groovy
exportService.export(params.formatName, response, "Vendor List", params.extension, project.vendors as List, fields, labels, [:], [titles:["Vendor List"], 'titles.mergeCells': true, 'titles.alignment': 'CENTRE'])
```
