### PR TITLE
Grails2 format-only column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Eclipse
+.classpath
+.project
+.gradle
+.slcache
+build/
+.settings/
+target-eclipse/
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
+*.log
+test/reports
+target
+/docs
+.DS_Store
+plugin.xml
+*.zip
+*.zip.sha1
+web-app
+*~

--- a/src/groovy/de/andreasschmitt/export/exporter/AbstractExporter.groovy
+++ b/src/groovy/de/andreasschmitt/export/exporter/AbstractExporter.groovy
@@ -37,7 +37,7 @@ abstract class AbstractExporter implements Exporter {
 	}
 	
 	protected Object getValue(Object domain, String field){
-		return formatValue(domain, ExporterUtil.getNestedValue(domain, field), field)
+		return formatValue(domain, ExporterUtil.getNestedValue(domain, field, formatters?.containsKey(field)), field)
 	}
 	
 	protected Writer getOutputStreamWriter(OutputStream outputStream) {

--- a/src/groovy/de/andreasschmitt/export/exporter/ExporterUtil.groovy
+++ b/src/groovy/de/andreasschmitt/export/exporter/ExporterUtil.groovy
@@ -24,7 +24,7 @@ class ExporterUtil {
 		throw new AssertionError()
 	}
 	
-	public static Object getNestedValue(Object domain, String field){
+	public static Object getNestedValue(Object domain, String field, boolean hasFormatter){
 		try {
 			// Doesn't work for dynamic properties such as tags used in taggable
 			return PropertyUtils.getProperty(domain, field)
@@ -35,13 +35,14 @@ class ExporterUtil {
 			
 			int i = 0
 			def lastProp
+			def lastE
 			for(prop in subProps){
 				if(i == 0){
 					try {
 						lastProp = domain?."$prop"
 					}
 					catch(Exception e){
-						log.info("Couldn't retrieve property ${prop}", e)
+						lastE = e
 					}
 				}
 				else {
@@ -49,10 +50,14 @@ class ExporterUtil {
 						lastProp = lastProp?."$prop"
 					}
 					catch(Exception e){
-						log.info("Couldn't retrieve property ${prop}", e)
+						lastE = e
 					}
 				}
 				i += 1
+			}
+
+			if (lastE && !hasFormatter) {
+				log.info("Couldn't retrieve property ${field}", lastE)
 			}
 			
 			return lastProp


### PR DESCRIPTION
Changed error reporting when an export column name matches a formatter's name but not the name of the underlying data.
