### PR TITLE
Column autosize applies on size() of rows instead of columns

### DIFF
--- a/src/groovy/de/andreasschmitt/export/builder/ExcelBuilder.groovy
+++ b/src/groovy/de/andreasschmitt/export/builder/ExcelBuilder.groovy
@@ -143,7 +143,7 @@ class ExcelBuilder extends BuilderSupport {
 						}
 					} else {
                         if(attributes?.widthAutoSize){
-                            for(int i = 0; i < attributes.numberOfFields - 1; i++){
+                            for(int i = 0; i < attributes.numberOfFields; i++){
                                 sheet.setColumnView(i, new CellView(autosize: true))
                             }
                         }

--- a/src/groovy/de/andreasschmitt/export/exporter/DefaultExcelExporter.groovy
+++ b/src/groovy/de/andreasschmitt/export/exporter/DefaultExcelExporter.groovy
@@ -27,7 +27,7 @@ class DefaultExcelExporter extends AbstractExporter {
 
             builder {
                 workbook(outputStream: outputStream){
-                    sheet(name: getParameters().get("title") ?: "Export", widths: getParameters().get("column.widths"), numberOfFields: data.size(), widthAutoSize: getParameters().get("column.width.autoSize")) {
+                    sheet(name: getParameters().get("title") ?: "Export", widths: getParameters().get("column.widths"), numberOfFields: fields.size(), widthAutoSize: getParameters().get("column.width.autoSize")) {
 
                         format(name: "title") {
                             Alignment alignment = Alignment.GENERAL


### PR DESCRIPTION
Hi,

The more **rows** I add in file - the more **columns** get autosized with "column.width.autoSize" parameter. 

This is a grails2 plugin, but I was surprised to see a reworked version of this code in grails3 plugin, that takes multiple sheets in account...

Maybe I'm not understanding this feature correctly, but anyway here is a code that rely on number of fields when applying column setting. Please take a look.