### PR TITLE
Update links and CI workflow to use Grails Plugin Collective (GPC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           -PskipCodeStyle
   publish:
     # only run the publishing task on this repo (not on forks)
-    if: github.repository_owner == 'grails-plugins' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: github.repository_owner == 'gpc' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: build
     name: "Publish Snapshot"
     runs-on: ubuntu-24.04

--- a/docs/src/docs/index.tmpl
+++ b/docs/src/docs/index.tmpl
@@ -308,7 +308,7 @@
     </main>
 
     <footer class="footer">
-        <p>Built by the <a href="https://github.com/grails-plugins">Grails Plugins</a> team</p>
+        <p>Built by the <a href="https://github.com/gpc">Grails Plugin Collective (GPC)</a> team</p>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
This pull request updates project references from "grails-plugins" to "gpc" (Grails Plugin Collective) to reflect the new organization name. The main changes involve updating the repository owner in the CI workflow and updating the footer in the documentation.

Repository and documentation updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL63-R63): Changed the `github.repository_owner` check from `'grails-plugins'` to `'gpc'` in the publish job condition.
* [`docs/src/docs/index.tmpl`](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edL311-R311): Updated the footer text and link to reference the "Grails Plugin Collective (GPC)" instead of "Grails Plugins."