### PR TITLE
refactor: replace hardcoded URLs etc. with dynamic placeholders for improved configurability

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -20,6 +20,7 @@ allprojects { project ->
 
 dependencies {
     implementation platform("org.apache.grails:grails-bom:${gradleProperties.grailsVersion}")
+    implementation 'org.apache.groovy:groovy-yaml'
     implementation 'cloud.wondrify:asset-pipeline-gradle'
     implementation "com.adarshr:gradle-test-logger-plugin:${gradleProperties.testLoggerVersion}"
     implementation 'org.apache.grails:grails-gradle-plugins'

--- a/build-logic/src/main/groovy/config.contributors.gradle
+++ b/build-logic/src/main/groovy/config.contributors.gradle
@@ -1,0 +1,9 @@
+
+def fetchContributors = tasks.register("fetchContributors", contributor.ContributorTask) {
+    repoOwner.convention(providers.gradleProperty('githubOrg'))
+    repoName.convention(providers.gradleProperty('githubProject'))
+    githubToken.convention(providers.environmentVariable('GITHUB_TOKEN'))
+    yamlOutput.convention(layout.buildDirectory.file("generated/contributors.yml"))
+}
+
+extensions.add("contributorsData", fetchContributors.flatMap { it.contributors })

--- a/build-logic/src/main/groovy/config.docs.gradle
+++ b/build-logic/src/main/groovy/config.docs.gradle
@@ -65,40 +65,58 @@ tasks.register('ghPagesRootIndexPage') {
     group = 'documentation'
 
     def templateFile = docProject.map { it.layout.projectDirectory.file('src/docs/index.tmpl') }
-    def outputFile   = rootProject.layout.buildDirectory.file('docs/ghpages.html')
+    def outputFile = rootProject.layout.buildDirectory.file('docs/ghpages.html')
 
     inputs.file(templateFile)
     outputs.file(outputFile)
 
     doLast {
-        def githubUser    = rootProject.findProperty('githubUser') as String
+        def githubUser = rootProject.findProperty('githubUser') as String
         def githubProject = rootProject.findProperty('githubProject') as String
 
         List<String> versions = []
+        String latestVersion = ""
         try {
             def conn = URI.create("https://api.github.com/repos/${githubUser}/${githubProject}/contents/?ref=gh-pages").toURL().openConnection()
             conn.setRequestProperty('Accept', 'application/vnd.github+json')
             conn.setRequestProperty('User-Agent', 'gradle-docs-build')
             def parsed = new groovy.json.JsonSlurper().parse(conn.inputStream)
             versions = (parsed as List)
-                .findAll { it.type == 'dir' }
-                .collect { it.name as String }
-                .findAll { it ==~ /\d+\.\d+\.(\d+|x)(-.*)?/ }
-                .sort()
-                .reverse()
+                    .findAll { it.type == 'dir' }
+                    .collect { it.name as String }
+                    .findAll { it ==~ /\d+\.\d+\.(\d+|x)(-.*)?/ }
+                    .toSorted { a, b ->
+                        // Parse into [major, minor, patch, qualifier]
+                        // patch 'x' becomes -1 so it sorts below any numeric patch
+                        // qualifier '' (stable) sorts above any pre-release string
+                        def parseVer = { String v ->
+                            def m = v =~ /^(\d+)\.(\d+)\.(x|\d+)(?:-(.+))?$/
+                            if (!m) return [0, 0, -2, '']
+                            [m[0][1] as int, m[0][2] as int, m[0][3] == 'x' ? -1 : m[0][3] as int, m[0][4] ?: '']
+                        }
+                        def av = parseVer(a)
+                        def bv = parseVer(b)
+                        return bv[0] <=> av[0] ?: bv[1] <=> av[1] ?: bv[2] <=> av[2] ?:
+                                (!av[3] && bv[3] ? -1 : av[3] && !bv[3] ? 1 : bv[3] <=> av[3]) // RC and other postfix versions
+                    }
+            latestVersion = versions ? versions.first() : ''
         } catch (Exception e) {
             logger.warn("ghPagesRootIndexPage: could not fetch GitHub versions — ${e.message}")
         }
 
         String optionsHtml = versions
-            ? versions.collect { v -> "<option value=\"${v}\">${v}</option>" }.join('\n                    ')
-            : '<option value="" disabled>No previous versions available</option>'
+                ? versions.collect { v -> "<option value=\"${v}\">${v}</option>" }.join('\n                    ')
+                : '<option value="" disabled>No previous versions available</option>'
 
         def tokens = [
-            '@OTHER_VERSIONS_OPTIONS@': optionsHtml,
-            '@GITHUB_REPO_URL@'       : "https://github.com/${githubUser}/${githubProject}",
-            '@GITHUB_ORG_URL@'        : "https://github.com/${githubUser}",
-            '@REPO_SLUG@'             : githubProject,
+                '@LATEST_VERSION@'        : latestVersion,
+                '@OTHER_VERSIONS_OPTIONS@': optionsHtml,
+                '@GITHUB_REPO_URL@'       : "https://github.com/${githubUser}/${githubProject}",
+                '@GITHUB_ORG_URL@'        : "https://github.com/${githubUser}",
+                '@PROJECT_TITLE@'         : "${projectTitle}",
+                '@PROJECT_DESCRIPTION@'   : "${projectDescription}",
+                '@PROJECT_ORG@'           : "${projectOrg}",
+                '@REPO_SLUG@'             : githubProject,
         ]
 
         def out = outputFile.get().asFile

--- a/build-logic/src/main/groovy/config.docs.gradle
+++ b/build-logic/src/main/groovy/config.docs.gradle
@@ -71,9 +71,12 @@ tasks.register('ghPagesRootIndexPage') {
     outputs.file(outputFile)
 
     doLast {
+        def githubUser    = rootProject.findProperty('githubUser') as String
+        def githubProject = rootProject.findProperty('githubProject') as String
+
         List<String> versions = []
         try {
-            def conn = URI.create('https://api.github.com/repos/gpc/grails-export/contents/?ref=gh-pages').toURL().openConnection()
+            def conn = URI.create("https://api.github.com/repos/${githubUser}/${githubProject}/contents/?ref=gh-pages").toURL().openConnection()
             conn.setRequestProperty('Accept', 'application/vnd.github+json')
             conn.setRequestProperty('User-Agent', 'gradle-docs-build')
             def parsed = new groovy.json.JsonSlurper().parse(conn.inputStream)
@@ -91,8 +94,17 @@ tasks.register('ghPagesRootIndexPage') {
             ? versions.collect { v -> "<option value=\"${v}\">${v}</option>" }.join('\n                    ')
             : '<option value="" disabled>No previous versions available</option>'
 
+        def tokens = [
+            '@OTHER_VERSIONS_OPTIONS@': optionsHtml,
+            '@GITHUB_REPO_URL@'       : "https://github.com/${githubUser}/${githubProject}",
+            '@GITHUB_ORG_URL@'        : "https://github.com/${githubUser}",
+            '@REPO_SLUG@'             : githubProject,
+        ]
+
         def out = outputFile.get().asFile
         out.parentFile.mkdirs()
-        out.text = templateFile.get().asFile.text.replace('@OTHER_VERSIONS_OPTIONS@', optionsHtml)
+        def content = templateFile.get().asFile.text
+        tokens.each { token, value -> content = content.replace(token, value) }
+        out.text = content
     }
 }

--- a/build-logic/src/main/groovy/config.docs.gradle
+++ b/build-logic/src/main/groovy/config.docs.gradle
@@ -71,13 +71,13 @@ tasks.register('ghPagesRootIndexPage') {
     outputs.file(outputFile)
 
     doLast {
-        def githubUser = rootProject.findProperty('githubUser') as String
+        def githubOrg = rootProject.findProperty('githubOrg') as String
         def githubProject = rootProject.findProperty('githubProject') as String
 
         List<String> versions = []
         String latestVersion = ""
         try {
-            def conn = URI.create("https://api.github.com/repos/${githubUser}/${githubProject}/contents/?ref=gh-pages").toURL().openConnection()
+            def conn = URI.create("https://api.github.com/repos/${githubOrg}/${githubProject}/contents/?ref=gh-pages").toURL().openConnection()
             conn.setRequestProperty('Accept', 'application/vnd.github+json')
             conn.setRequestProperty('User-Agent', 'gradle-docs-build')
             def parsed = new groovy.json.JsonSlurper().parse(conn.inputStream)
@@ -111,8 +111,8 @@ tasks.register('ghPagesRootIndexPage') {
         def tokens = [
                 '@LATEST_VERSION@'        : latestVersion,
                 '@OTHER_VERSIONS_OPTIONS@': optionsHtml,
-                '@GITHUB_REPO_URL@'       : "https://github.com/${githubUser}/${githubProject}",
-                '@GITHUB_ORG_URL@'        : "https://github.com/${githubUser}",
+                '@GITHUB_REPO_URL@'       : "https://github.com/${githubOrg}/${githubProject}",
+                '@GITHUB_ORG_URL@'        : "https://github.com/${githubOrg}",
                 '@PROJECT_TITLE@'         : "${projectTitle}",
                 '@PROJECT_DESCRIPTION@'   : "${projectDescription}",
                 '@PROJECT_ORG@'           : "${projectOrg}",

--- a/build-logic/src/main/groovy/contributor/ContributorTask.groovy
+++ b/build-logic/src/main/groovy/contributor/ContributorTask.groovy
@@ -34,9 +34,9 @@ abstract class ContributorTask extends DefaultTask {
     Provider<Map<String, String>> getContributors() {
         yamlOutput.map { regularFile ->
             def yamlFile = regularFile.asFile
-            if (!yamlFile.exists()) return Collections.<String, String> emptyMap()
+            if (!yamlFile.exists()) return Collections.<String, String>emptyMap()
             def yaml = new YamlSlurper().parse(yamlFile) as Map<String, Serializable>
-            yaml.contributors as Map<String, String>
+            (yaml.contributors ?: [:]) as Map<String, String>
         }
     }
 
@@ -48,7 +48,9 @@ abstract class ContributorTask extends DefaultTask {
 
         if (!token) {
             logger.warn("No GITHUB_TOKEN — skipping contributor fetch for ${repoOwner.get()}/${repoName.get()}")
-            outputFile.text = "contributors:\n"
+            YamlBuilder emptyYaml = new YamlBuilder()
+            emptyYaml contributors: [:]
+            outputFile.text = emptyYaml.toString()
             return
         }
 

--- a/build-logic/src/main/groovy/contributor/ContributorTask.groovy
+++ b/build-logic/src/main/groovy/contributor/ContributorTask.groovy
@@ -1,0 +1,95 @@
+package contributor
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import groovy.yaml.YamlSlurper
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.impldep.org.testng.internal.YamlParser
+
+abstract class ContributorTask extends DefaultTask {
+
+    @Input
+    abstract Property<String> getRepoOwner()
+
+    @Input
+    abstract Property<String> getRepoName()
+
+    @Input
+    @Optional
+    abstract Property<String> getGithubToken()
+
+    @OutputFile
+    abstract RegularFileProperty getYamlOutput()
+
+    @Internal
+    Provider<Map<String, String>> getContributors() {
+        yamlOutput.map { regularFile ->
+            def yamlFile = regularFile.asFile
+            if (!yamlFile.exists()) return Collections.<String, String> emptyMap()
+            yamlFile.readLines()
+                    .findAll { it.startsWith('  ') && it.contains(': ') }
+                    .collectEntries { line ->
+                        def colon = line.indexOf(': ')
+                        def key = line.substring(2, colon)
+                        def raw = line.substring(colon + 2).trim()
+                        def val = (raw.startsWith("'") && raw.endsWith("'")) ? raw[1..-2].replace("''", "'") : raw
+                        [(key): val]
+                    } as Map<String, String>
+        }
+    }
+
+    @TaskAction
+    void generate() {
+        def token = githubToken.orNull
+        def outputFile = yamlOutput.get().asFile
+        outputFile.parentFile.mkdirs()
+
+        if (!token) {
+            logger.warn("No GITHUB_TOKEN — skipping contributor fetch for ${repoOwner.get()}/${repoName.get()}")
+            outputFile.text = "contributors:\n"
+            return
+        }
+
+        // 1. Fetch from REST (sorted by contributions, bots excluded)
+        def restUrl = "https://api.github.com/repos/${repoOwner.get()}/${repoName.get()}/contributors"
+        def contributors = new JsonSlurper().parseText(
+                restUrl.toURL().getText(requestProperties: [Authorization: "token $token"])
+        ).findAll { it.type != 'Bot' } as List<Map<String, Serializable>>
+
+        def sortedNodes = contributors*.node_id
+        def loginMap = contributors.collectEntries { [it.node_id, it.login] } as Map<String, String>
+
+        // 2. Fetch display names via GraphQL
+        def gqlQuery = 'query($ids: [ID!]!) { nodes(ids: $ids) { ... on User { id name login } } }'
+        def body = JsonOutput.toJson([query: gqlQuery, variables: [ids: sortedNodes]])
+
+        def connection = "https://api.github.com/graphql".toURL().openConnection() as HttpURLConnection
+        connection.with {
+            doOutput = true
+            requestMethod = 'POST'
+            setRequestProperty('Authorization', "bearer $token")
+            outputStream.withWriter { it << body }
+        }
+
+        def gqlResponse = new JsonSlurper().parseText(connection.inputStream.text)
+        def nameLookup = gqlResponse.data.nodes.collectEntries { [it.id, it.name ?: it.login] } as Map<String, String>
+
+        // 3. Write YAML output (login → display name, preserving contribution order)
+        def finalMap = sortedNodes
+                .findAll { loginMap[it] }
+                .collectEntries { id -> [loginMap[id], nameLookup[id] ?: loginMap[id]] } as Map<String, String>
+
+        outputFile.text = "contributors:\n" + finalMap.collect { k, v ->
+            "  $k: '${v.replace("'", "''")}'"
+        }.join("\n")
+    }
+}

--- a/build-logic/src/main/groovy/contributor/ContributorTask.groovy
+++ b/build-logic/src/main/groovy/contributor/ContributorTask.groovy
@@ -2,6 +2,7 @@ package contributor
 
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import groovy.yaml.YamlBuilder
 import groovy.yaml.YamlSlurper
 
 import org.gradle.api.DefaultTask
@@ -13,7 +14,6 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.impldep.org.testng.internal.YamlParser
 
 abstract class ContributorTask extends DefaultTask {
 
@@ -35,15 +35,8 @@ abstract class ContributorTask extends DefaultTask {
         yamlOutput.map { regularFile ->
             def yamlFile = regularFile.asFile
             if (!yamlFile.exists()) return Collections.<String, String> emptyMap()
-            yamlFile.readLines()
-                    .findAll { it.startsWith('  ') && it.contains(': ') }
-                    .collectEntries { line ->
-                        def colon = line.indexOf(': ')
-                        def key = line.substring(2, colon)
-                        def raw = line.substring(colon + 2).trim()
-                        def val = (raw.startsWith("'") && raw.endsWith("'")) ? raw[1..-2].replace("''", "'") : raw
-                        [(key): val]
-                    } as Map<String, String>
+            def yaml = new YamlSlurper().parse(yamlFile) as Map<String, Serializable>
+            yaml.contributors as Map<String, String>
         }
     }
 
@@ -88,8 +81,8 @@ abstract class ContributorTask extends DefaultTask {
                 .findAll { loginMap[it] }
                 .collectEntries { id -> [loginMap[id], nameLookup[id] ?: loginMap[id]] } as Map<String, String>
 
-        outputFile.text = "contributors:\n" + finalMap.collect { k, v ->
-            "  $k: '${v.replace("'", "''")}'"
-        }.join("\n")
+        YamlBuilder yaml = new YamlBuilder()
+        yaml contributors: finalMap
+        outputFile.text = yaml.toString()
     }
 }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -17,7 +17,7 @@ def asciidoctorAttributes = [
         idprefix            : '',
         idseparator         : '-',
         version             : project.version,
-        projectUrl          : "https://github.com/${rootProject.findProperty('githubUser')}/${rootProject.findProperty('githubProject')}",
+        projectUrl          : "https://github.com/${rootProject.findProperty('githubOrg')}/${rootProject.findProperty('githubProject')}",
         sourcedir           : "${rootProject.allprojects.find { it.name == 'grails-export' }.projectDir}/src/main/groovy",
         grailsVersion       : grailsVersion
 ]

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -17,10 +17,9 @@ def asciidoctorAttributes = [
         idprefix            : '',
         idseparator         : '-',
         version             : project.version,
-        projectUrl          : 'https://github.com/gpc/grails-export',
+        projectUrl          : "https://github.com/${rootProject.findProperty('githubUser')}/${rootProject.findProperty('githubProject')}",
         sourcedir           : "${rootProject.allprojects.find { it.name == 'grails-export' }.projectDir}/src/main/groovy",
         grailsVersion       : grailsVersion
-//        grailsDocBase       : "https://grails.apache.org/docs/${resolveGrailsDocsDirName(project.grailsVersion)}"
 ]
 
 tasks.named('asciidoctor', AsciidoctorTask) {

--- a/docs/src/docs/index.tmpl
+++ b/docs/src/docs/index.tmpl
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Export - Grails Plugin</title>
+    <title>@PROJECT_TITLE@</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -294,8 +294,8 @@
             View on GitHub
         </a>
         <div class="hero-content">
-            <h1>Export</h1>
-            <p class="subtitle">A Grails plugin that adds export functionality for CSV, Excel, ODS, PDF, RTF, and XML formats</p>
+            <h1>@PROJECT_TITLE@</h1>
+            <p class="subtitle">@PROJECT_DESCRIPTION@</p>
         </div>
     </header>
 
@@ -305,6 +305,7 @@
         <div class="docs-grid">
             <div class="doc-card">
                 <span class="version-badge latest">Latest Release</span>
+                <span class="version-badge latest">@LATEST_VERSION@</span>
                 <h3>Stable Version</h3>
                 <div class="links">
                     <a href="/@REPO_SLUG@/latest/" class="link">
@@ -383,7 +384,7 @@
     </script>
 
     <footer class="footer">
-        <p>Built by the <a href="@GITHUB_ORG_URL@">Grails Plugin Collective (GPC)</a> team</p>
+        <p>Built by the <a href="@GITHUB_ORG_URL@">@PROJECT_ORG@</a> team</p>
     </footer>
 </body>
 </html>

--- a/docs/src/docs/index.tmpl
+++ b/docs/src/docs/index.tmpl
@@ -287,7 +287,7 @@
 </head>
 <body>
     <header class="hero">
-        <a href="https://github.com/gpc/grails-export" class="github-link">
+        <a href="@GITHUB_REPO_URL@" class="github-link">
             <svg viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
             </svg>
@@ -307,13 +307,13 @@
                 <span class="version-badge latest">Latest Release</span>
                 <h3>Stable Version</h3>
                 <div class="links">
-                    <a href="/grails-export/latest/" class="link">
+                    <a href="/@REPO_SLUG@/latest/" class="link">
                         <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
                         </svg>
                         User Guide
                     </a>
-                    <a href="/grails-export/latest/gapi/" class="link">
+                    <a href="/@REPO_SLUG@/latest/gapi/" class="link">
                         <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
                         </svg>
@@ -326,13 +326,13 @@
                 <span class="version-badge snapshot">Snapshot</span>
                 <h3>Development Version</h3>
                 <div class="links">
-                    <a href="/grails-export/snapshot/" class="link">
+                    <a href="/@REPO_SLUG@/snapshot/" class="link">
                         <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
                         </svg>
                         User Guide
                     </a>
-                    <a href="/grails-export/snapshot/gapi/" class="link">
+                    <a href="/@REPO_SLUG@/snapshot/gapi/" class="link">
                         <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
                         </svg>
@@ -375,15 +375,15 @@
             function update() {
                 var v = sel.value;
                 if (!v) return;
-                guide.href = '/grails-export/' + v + '/';
-                api.href   = '/grails-export/' + v + '/gapi/';
+                guide.href = '/@REPO_SLUG@/' + v + '/';
+                api.href   = '/@REPO_SLUG@/' + v + '/gapi/';
             }
             sel.addEventListener('change', update);
         })();
     </script>
 
     <footer class="footer">
-        <p>Built by the <a href="https://github.com/gpc">Grails Plugin Collective (GPC)</a> team</p>
+        <p>Built by the <a href="@GITHUB_ORG_URL@">Grails Plugin Collective (GPC)</a> team</p>
     </footer>
 </body>
 </html>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,12 @@
 projectVersion=7.0.1-SNAPSHOT
 grailsVersion=7.0.10
+# GitHub repository metadata
 githubUser=gpc
 githubProject=grails-export
+# Project metadata
+projectTitle=Grails Export Plugin
+projectDescription=A Grails plugin that adds export functionality for CSV, Excel, ODS, PDF, RTF, and XML formats.
+projectOrg=Grails Plugin Collective (GPC)
 # Comma-separated list of projects to publish
 projectsToPublish=grails-export
 # Build dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 projectVersion=7.0.1-SNAPSHOT
 grailsVersion=7.0.10
 # GitHub repository metadata
-githubUser=gpc
+githubOrg=gpc
 githubProject=grails-export
 # Project metadata
 projectTitle=Grails Export Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 projectVersion=7.0.1-SNAPSHOT
 grailsVersion=7.0.10
+githubUser=gpc
+githubProject=grails-export
 # Comma-separated list of projects to publish
 projectsToPublish=grails-export
 # Build dependencies

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -12,7 +12,7 @@ if (bintrayProperties.exists()) {
     user = project.bintrayUsername
     key = project.bintrayApiKey
 
-    githubSlug = "${project.findProperty('githubUser')}/${project.findProperty('githubProject')}"
+    githubSlug = "${project.findProperty('githubOrg')}/${project.findProperty('githubProject')}"
 
     license {
       name = 'Apache-2.0'
@@ -50,7 +50,7 @@ if (githubProperties.exists()) {
   }
 
   githubPages {
-    repoUri = "https://github.com/${project.findProperty('githubUser')}/${project.findProperty('githubProject')}.git"
+    repoUri = "https://github.com/${project.findProperty('githubOrg')}/${project.findProperty('githubProject')}.git"
 
     credentials {
       username = project.hasProperty('githubApiKey') ? project.githubApiKey : ''

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -12,13 +12,13 @@ if (bintrayProperties.exists()) {
     user = project.bintrayUsername
     key = project.bintrayApiKey
 
-    githubSlug = 'gpc/grails-export'
+    githubSlug = "${project.findProperty('githubUser')}/${project.findProperty('githubProject')}"
 
     license {
       name = 'Apache-2.0'
     }
 
-    title = "Export"
+    title = "Grails Export Plugin"
     desc = "This plugin offers export functionality supporting different formats e.g. CSV, Excel, Open Document Spreadsheet, PDF and XML and can be extended to add additional formats."
 
 	developers = [  graemerocher: 'Graeme Rocher', 
@@ -50,7 +50,7 @@ if (githubProperties.exists()) {
   }
 
   githubPages {
-    repoUri = 'https://github.com/gpc/grails-export.git'
+    repoUri = "https://github.com/${project.findProperty('githubUser')}/${project.findProperty('githubProject')}.git"
 
     credentials {
       username = project.hasProperty('githubApiKey') ? project.githubApiKey : ''

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -41,10 +41,10 @@ extensions.configure(org.apache.grails.gradle.publish.GrailsPublishExtension) {
     it.artifactId = project.name
     it.githubSlug = "${githubUser}/${githubProject}"
     it.license.name = 'Apache-2.0'
-    it.title = 'Grails Export Plugin'
-    it.desc = 'This plugin offers export functionality supporting different formats e.g. CSV, Excel, Open Document Spreadsheet, PDF and XML and can be extended to add additional formats.'
+    it.title = "${projectTitle}"
+    it.desc = "${projectDescription}"
     it.organization {
-        it.name = 'Grails Plugin Collective (GPC)'
+        it.name = "${projectOrg}"
         it.url = "https://github.com/${githubUser}"
     }
     it.developers = [

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -36,14 +36,16 @@ dependencies {
 }
 
 extensions.configure(org.apache.grails.gradle.publish.GrailsPublishExtension) {
+    def githubUser    = rootProject.findProperty('githubUser')
+    def githubProject = rootProject.findProperty('githubProject')
     it.artifactId = project.name
-    it.githubSlug = 'gpc/grails-export'
+    it.githubSlug = "${githubUser}/${githubProject}"
     it.license.name = 'Apache-2.0'
     it.title = 'Grails Export Plugin'
     it.desc = 'This plugin offers export functionality supporting different formats e.g. CSV, Excel, Open Document Spreadsheet, PDF and XML and can be extended to add additional formats.'
     it.organization {
         it.name = 'Grails Plugin Collective (GPC)'
-        it.url = 'https://github.com/gpc'
+        it.url = "https://github.com/${githubUser}"
     }
     it.developers = [
             graemerocher:'Graeme Rocher',

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,8 +1,11 @@
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom
+
 plugins {
     id 'config.compile'
     id 'config.grails-plugin'
     id 'config.publish'
     id 'config.testing'
+    id 'config.contributors'
 }
 
 version = projectVersion
@@ -36,8 +39,6 @@ dependencies {
 }
 
 extensions.configure(org.apache.grails.gradle.publish.GrailsPublishExtension) {
-    def githubUser    = rootProject.findProperty('githubOrg')
-    def githubProject = rootProject.findProperty('githubProject')
     it.artifactId = project.name
     it.githubSlug = "${githubOrg}/${githubProject}"
     it.license.name = 'Apache-2.0'
@@ -47,20 +48,20 @@ extensions.configure(org.apache.grails.gradle.publish.GrailsPublishExtension) {
         it.name = "${projectOrg}"
         it.url = "https://github.com/${githubOrg}"
     }
-    it.developers = [
-            graemerocher:'Graeme Rocher',
-            puneetbehl: 'Puneet Behl',
-            nwwells: 'Nathan Wells',
-            tulu: 'Ruben',
-            arturoojeda: 'Arturo Ojeda López',
-            fabiooshiro: 'Fabio Issamu Oshiro',
-            ddelponte: 'Dean Del Ponte',
-            cristallo: 'Cristiano Limiti',
-            mirweb: 'Mirko Weber',
-            joasgarcia: 'Joás Garcia',
-            frangarcia: 'Fran García',
-            dustindclark: 'Dustin Clark',
-            miq: 'Mihael Koep',
-            sbglasius: 'Søren Berg Glasius'
-    ]
+}
+
+pluginManager.withPlugin('maven-publish') {
+    tasks.withType(GenerateMavenPom).configureEach { pomTask ->
+        dependsOn(tasks.named('fetchContributors'))
+        doFirst {
+            pomTask.pom.developers { spec ->
+                contributorsData.get().each { String login, String displayName ->
+                    spec.developer {
+                        id = login
+                        name = displayName
+                    }
+                }
+            }
+        }
+    }
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -36,16 +36,16 @@ dependencies {
 }
 
 extensions.configure(org.apache.grails.gradle.publish.GrailsPublishExtension) {
-    def githubUser    = rootProject.findProperty('githubUser')
+    def githubUser    = rootProject.findProperty('githubOrg')
     def githubProject = rootProject.findProperty('githubProject')
     it.artifactId = project.name
-    it.githubSlug = "${githubUser}/${githubProject}"
+    it.githubSlug = "${githubOrg}/${githubProject}"
     it.license.name = 'Apache-2.0'
     it.title = "${projectTitle}"
     it.desc = "${projectDescription}"
     it.organization {
         it.name = "${projectOrg}"
-        it.url = "https://github.com/${githubUser}"
+        it.url = "https://github.com/${githubOrg}"
     }
     it.developers = [
             graemerocher:'Graeme Rocher',


### PR DESCRIPTION
This pull request introduces dynamic project and repository metadata handling, automates contributor fetching, and improves documentation and publishing workflows by centralizing configuration and using templates. The main themes are metadata centralization, automation, and improved maintainability.

**Project and Repository Metadata Centralization:**

* Added new properties to `gradle.properties` for GitHub org, project, and project metadata, and updated all references in build scripts and documentation templates to use these properties instead of hardcoded values. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R3-R9) [[2]](diffhunk://#diff-dc8e1264edf1b5783bcf1aa7eeeaa4f4b4b5089fa97f951d1be97ccd604047b8L20-L23) [[3]](diffhunk://#diff-f84b31486d438ea87b55ce5d9a4e3b36fc72c39183bdcecd15a144b9e00a4d45L15-R21) [[4]](diffhunk://#diff-f84b31486d438ea87b55ce5d9a4e3b36fc72c39183bdcecd15a144b9e00a4d45L53-R53) [[5]](diffhunk://#diff-520f178549fabd7e74f5b1fedb7275a1434a2ac153fc49e0212455ceeef38e37L40-L63) [[6]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edL6-R6) [[7]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edL290-R298) [[8]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edR308-R317) [[9]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edL329-R336) [[10]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edL378-R387)

**Automated Contributor Fetching and Publishing:**

* Added a new `ContributorTask` (`build-logic/src/main/groovy/contributor/ContributorTask.groovy`) and `config.contributors.gradle` to fetch contributors from GitHub, store them as YAML, and expose them for use in publishing. [[1]](diffhunk://#diff-62b698097a817638b5610fbe7969da70a2393e60b9cadc293c6178d41ecd2d9fR1-R90) [[2]](diffhunk://#diff-c3fcaa298dac336a11c40e937ca45b44e08e0078652b2b7ebb2d7609b00a1a17R1-R9)
* Integrated the contributors task into the plugin build so that Maven POM files are automatically populated with up-to-date contributor information. [[1]](diffhunk://#diff-520f178549fabd7e74f5b1fedb7275a1434a2ac153fc49e0212455ceeef38e37R1-R8) [[2]](diffhunk://#diff-520f178549fabd7e74f5b1fedb7275a1434a2ac153fc49e0212455ceeef38e37L40-L63)

**Documentation Improvements:**

* Updated the documentation index template (`docs/src/docs/index.tmpl`) to use tokens for project/repo metadata and versioning, and improved version sorting and selection in the documentation generation Gradle task. [[1]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edL6-R6) [[2]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edL290-R298) [[3]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edR308-R317) [[4]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edL329-R336) [[5]](diffhunk://#diff-9fd8441f94e5b81c44b5d4d1599ecd6b4fb7ec5522d7a368ff79c0290b9442edL378-R387) [[6]](diffhunk://#diff-91324e64885f9312141bec0a7bbffddb084741ae6b18aaa8d975dfbf2a47a777R74-R102) [[7]](diffhunk://#diff-91324e64885f9312141bec0a7bbffddb084741ae6b18aaa8d975dfbf2a47a777R111-R126)
* The documentation build now dynamically injects the latest version and other metadata into the docs. [[1]](diffhunk://#diff-91324e64885f9312141bec0a7bbffddb084741ae6b18aaa8d975dfbf2a47a777R74-R102) [[2]](diffhunk://#diff-91324e64885f9312141bec0a7bbffddb084741ae6b18aaa8d975dfbf2a47a777R111-R126)

**Dependency Updates:**

* Added `org.apache.groovy:groovy-yaml` as a build dependency to support YAML processing for contributors.

These changes make the build and release process more maintainable and ensure that documentation and published artifacts always reflect the latest project state and contributor information.