### PR TITLE
Fix Maven link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.gpc/grails-export)](https://img.shields.io/maven-central/v/io.github.gpc/grails-export)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.gpc/grails-export)](https://central.sonatype.com/artifact/io.github.gpc/grails-export)
 [![License](https://img.shields.io/github/license/gpc/grails-export)](https://www.apache.org/licenses/LICENSE-2.0)
 [![CI](https://github.com/gpc/grails-export/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/gpc/grails-export/actions/workflows/ci.yml)
 


### PR DESCRIPTION
The link was to the shield icon not the plugin artifact